### PR TITLE
Fix missing storageclassname in PVC

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -405,7 +405,9 @@ func processPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) (string, ma
 	if provisionedBy == "ebs.csi.aws.com" {
 		if pv.Spec.CSI != nil {
 			volumeID = pv.Spec.CSI.VolumeHandle
-		}
+		} else {
+                        volumeID = parseAWSEBSVolumeID(pv.Spec.AWSElasticBlockStore.VolumeID)
+                }
 	} else if provisionedBy == "efs.csi.aws.com" {
 		if pv.Spec.CSI != nil {
 			volumeID = parseAWSEFSVolumeID(pv.Spec.CSI.VolumeHandle)


### PR DESCRIPTION
The "volume.beta.kubernetes.io/storage-class" annotation is deprecated but can be used to specify the name of StorageClass in PVC. When both storageClassName attribute and volume.beta.kubernetes.io/storage-class annotation are specified, the annotation volume.beta.kubernetes.io/storage-class takes precedence over the storageClassName attribute.

Ref: https://kubernetes.io/docs/reference/labels-annotations-taints/#volume-beta-kubernetes-io-storage-class-deprecated

```
│ {"level":"info","msg":"New PVC Added to Store","namespace":"default","pvc":"pvc-sc-annotation","time":"2023-04-22T10:51:35Z"}                                                                                    │
│ E0422 10:51:35.463691       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)                            │
│ goroutine 51 [running]:                                                                                                                                                                                          │
│ k8s.io/apimachinery/pkg/util/runtime.logPanic({0x18a8020?, 0x3190c00})                                                                                                                                           │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/runtime/runtime.go:75 +0x84                                                                                                                                 │
│ k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x40005cee60?})                                                                                                                                      │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/runtime/runtime.go:49 +0x80                                                                                                                                 │
│ panic({0x18a8020, 0x3190c00})                                                                                                                                                                                    │
│     /usr/local/go/src/runtime/panic.go:884 +0x20c                                                                                                                                                                │
│ main.watchForPersistentVolumeClaims.func1({0x1bd5aa0?, 0x4000658000})                                                                                                                                            │
│     /build/kubernetes.go:124 +0x22c                                                                                                                                                                              │
│ k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)                                                                                                                                                │
│     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/controller.go:232                                                                                                                                           │
│ k8s.io/client-go/tools/cache.(*processorListener).run.func1()                                                                                                                                                    │
│     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:911 +0x13c                                                                                                                               │
│ k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xce88?)                                                                                                                                                    │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:157 +0x40                                                                                                                                      │
│ k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x400005cf28?, {0x20ba240, 0x40000a5530}, 0x1, 0x4000102fc0)                                                                                                      │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:158 +0x90                                                                                                                                      │
│ k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0xc8?, 0x400005cf78?)                                                                                                                       │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:135 +0x80                                                                                                                                      │
│ k8s.io/apimachinery/pkg/util/wait.Until(...)                                                                                                                                                                     │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:92                                                                                                                                             │
│ k8s.io/client-go/tools/cache.(*processorListener).run(0x40000b6680?)                                                                                                                                             │
│     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:905 +0x68                                                                                                                                │
│ k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()                                                                                                                                                         │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x58                                                                                                                                       │
│ created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start                                                                                                                                                      │
│     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x84                                                                                                                                       │
│ panic: runtime error: invalid memory address or nil pointer dereference [recovered]                                                                                                                              │
│     panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                      │
│ [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x157ce1c]

```