### PR TITLE
Add possiblity to tag dynamically provisioned FSx volumes

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -204,15 +204,15 @@ func (client *EFSClient) deleteEFSVolumeTags(volumeID string, tags []string, sto
 
 func (client *FSxClient) addFSxVolumeTags(volumeID string, tags map[string]string, storageclass string) {
 	volumeIDs := []*string{&volumeID}
-	describeVolumesOutput, err := client.DescribeVolumes(&fsx.DescribeVolumesInput{
-		VolumeIds: volumeIDs,
+	describeFileSystemOutput, err := client.DescribeFileSystems(&fsx.DescribeFileSystemsInput{
+		FileSystemIds: volumeIDs,
 	})
 	if err != nil {
 		log.WithError(err)
 		return
 	}
 	_, err = client.TagResource(&fsx.TagResourceInput{
-		ResourceARN: describeVolumesOutput.Volumes[0].ResourceARN,
+		ResourceARN: describeFileSystemOutput.FileSystems[0].ResourceARN,
 		Tags:        convertTagsToFSxTags(tags),
 	})
 

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -417,7 +417,7 @@ func provisionedByAwsFsx(pvc *corev1.PersistentVolumeClaim) bool {
 	}
 
 	if provisionedBy == "fsx.csi.aws.com" {
-		log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName()}).Debugln("kubernetes.io/aws-ebs volume")
+		log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName()}).Debugln("fsx.csi.aws.com volume")
 		return true
 	}
 	return false

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -246,6 +246,53 @@ func Test_provisionedByAwsEfs(t *testing.T) {
 	}
 }
 
+func Test_provisionedByAwsFsx(t *testing.T) {
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvc.SetName("my-pvc")
+	pvc.Spec.StorageClassName = &dummyStorageClassName
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "valid provisioner fsx.csi.aws.com",
+			annotations: map[string]string{"volume.kubernetes.io/storage-provisioner": "fsx.csi.aws.com"},
+			want:        true,
+		},
+		{
+			name:        "invalid provisioner",
+			annotations: map[string]string{"volume.kubernetes.io/storage-provisioner": "something else"},
+			want:        false,
+		},
+		{
+			name:        "valid provisioner fsx.csi.aws.com legacy annotation",
+			annotations: map[string]string{"volume.beta.kubernetes.io/storage-provisioner": "fsx.csi.aws.com"},
+			want:        true,
+		},
+		{
+			name:        "invalid provisioner legacy annotation",
+			annotations: map[string]string{"volume.beta.kubernetes.io/storage-provisioner": "something else"},
+			want:        false,
+		},
+		{
+			name:        "provisioner not set",
+			annotations: map[string]string{"some annotation": "something else"},
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvc.SetAnnotations(tt.annotations)
+			if got := provisionedByAwsFsx(pvc); got != tt.want {
+				t.Errorf("provisionedByAwsEfs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_buildTags(t *testing.T) {
 
 	pvc := &corev1.PersistentVolumeClaim{}


### PR DESCRIPTION
Included FSx client in order to be able to tag PVCs provisioned by aws-fsx-csi-driver. Use case needed as we provision a lot of FSx volumes, and need to have them uniquely tagged.