### PR TITLE
Use tpl function for defaultTags in Deployment

### DIFF
--- a/charts/k8s-pvc-tagger/Chart.yaml
+++ b/charts/k8s-pvc-tagger/Chart.yaml
@@ -16,5 +16,5 @@ keywords:
 sources:
   - https://github.com/mtougeron/k8s-pvc-tagger
 
-version: 2.1.0
+version: 2.1.1
 appVersion: v1.1.0

--- a/charts/k8s-pvc-tagger/templates/deployment.yaml
+++ b/charts/k8s-pvc-tagger/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - --annotation-prefix={{ .Values.annotationPrefix }}
 {{- end }}
 {{- if .Values.defaultTags }}
-            - --default-tags={{ .Values.defaultTags | toJson }}
+            - --default-tags={{ tpl (.Values.defaultTags) $ | toJson }}
 {{- end }}
 {{- if .Values.watchNamespace }}
             - --watch-namespace={{ .Values.watchNamespace }}


### PR DESCRIPTION
This PR modifies the `defaultTags` argument in the Deployment configuration. Previously, the `defaultTags` value was directly converted to JSON. This PR changes this behavior by first passing the `defaultTags` through the Helm `tpl` function before converting it to JSON.

The `tpl` function allows us to use templating in the `defaultTags`values. This means we can now use values from other Helm variables within `defaultTags`. This provides more flexibility and dynamic configuration options for users.

This change is backward compatible. If no templating is used in defaultTags, the behavior remains the same as before.