### PR TITLE
Misc chart enhancements and appVersion v1.1.1

### DIFF
--- a/charts/k8s-pvc-tagger/Chart.yaml
+++ b/charts/k8s-pvc-tagger/Chart.yaml
@@ -9,6 +9,8 @@ maintainers:
 keywords:
   - kubernetes
   - aws
+  - eks
+  - pvc
   - gcp
   - aws-ebs
   - aws-efs
@@ -16,5 +18,5 @@ keywords:
 sources:
   - https://github.com/mtougeron/k8s-pvc-tagger
 
-version: 2.2.1
-appVersion: v1.1.0
+version: 2.2.2
+appVersion: v1.1.1

--- a/charts/k8s-pvc-tagger/templates/deployment.yaml
+++ b/charts/k8s-pvc-tagger/templates/deployment.yaml
@@ -5,16 +5,18 @@ metadata:
   labels:
     {{- include "k8s-pvc-tagger.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "k8s-pvc-tagger.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+      {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       labels:
         {{- include "k8s-pvc-tagger.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
@@ -96,6 +98,13 @@ spec:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       {{- if .Values.volumes }}
       volumes:
         # Extra volume(s)
@@ -112,4 +121,11 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/charts/k8s-pvc-tagger/templates/servicemonitor.yaml
+++ b/charts/k8s-pvc-tagger/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "k8s-pvc-tagger.fullname" . }}
+  namespace: {{ .Values.serviceMonitorNamespace | default .Release.Namespace }}
   labels:
     {{- include "k8s-pvc-tagger.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitorLabels }}

--- a/charts/k8s-pvc-tagger/values.yaml
+++ b/charts/k8s-pvc-tagger/values.yaml
@@ -79,6 +79,7 @@ watchNamespace: ""
 
 serviceMonitor: false
 serviceMonitorLabels: {}
+serviceMonitorNamespace: ""
 
 debug: false
 
@@ -86,3 +87,10 @@ extraEnvs: {}
 extraArgs: {}
 
 podLabels: {}
+
+dnsPolicy: ""
+dnsConfig: {}
+
+topologySpreadConstraints: []
+
+priorityClassName: ""


### PR DESCRIPTION
- appVersion v1.1.1
- Allow setting a different namespace for the ServiceMonitor than the one the app runs in
- Allow setting the DNS config for the pods
- Allow setting the topologySpreadConstraints
- Allow setting the priorityClassName
- Allow not setting the number of replicas for the Deployment in case you set your own HPA or something