### PR TITLE
Nil check to prevent panic when CSI source is not set.

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -616,7 +616,9 @@ func processPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) (string, ma
 	case AZURE_DISK_CSI:
 		volumeID = pv.Spec.CSI.VolumeHandle
 	case GCP_PD_CSI:
-		volumeID = pv.Spec.CSI.VolumeHandle
+		if pv.Spec.CSI != nil {
+			volumeID = pv.Spec.CSI.VolumeHandle
+		}
 	}
 
 	log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName(), "volumeID": volumeID}).Debugln("parsed volumeID:", volumeID)

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -968,6 +968,7 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 		tagsAnnotation string
 		volumeID       string
 		volumeName     string
+		source         string
 		wantedTags     map[string]string
 		wantedVolumeID string
 		wantedErr      bool
@@ -978,6 +979,7 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			tagsAnnotation: "{\"foo\": \"bar\"}",
 			volumeName:     volumeName,
 			volumeID:       "projects/my-project/zones/us-east1-a/disks/my-disk",
+			source:         "csi",
 			wantedTags:     map[string]string{"foo": "bar"},
 			wantedVolumeID: "projects/my-project/zones/us-east1-a/disks/my-disk",
 			wantedErr:      false,
@@ -988,6 +990,7 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			tagsAnnotation: "{\"foo\": \"bar\"}",
 			volumeName:     volumeName,
 			volumeID:       "projects/my-project/zones/us-east1-a/disks/my-disk",
+			source:         "gce",
 			wantedTags:     map[string]string{"foo": "bar"},
 			wantedVolumeID: "projects/my-project/zones/us-east1-a/disks/my-disk",
 			wantedErr:      false,
@@ -998,6 +1001,7 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			tagsAnnotation: "{\"foo\": \"bar\"}",
 			volumeName:     volumeName,
 			volumeID:       "",
+			source:         "gce",
 			wantedTags:     nil,
 			wantedVolumeID: "",
 			wantedErr:      true,
@@ -1007,6 +1011,7 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			provisionedBy:  "foo",
 			tagsAnnotation: "{\"foo\": \"bar\"}",
 			volumeName:     volumeName,
+			source:         "gce",
 			wantedTags:     nil,
 			wantedVolumeID: "",
 			wantedErr:      true,
@@ -1017,6 +1022,17 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			tagsAnnotation: "{\"foo\": \"bar\"}",
 			volumeName:     "asdf",
 			volumeID:       "projects/my-project/zones/us-east1-a/disks/my-disk",
+			source:         "gce",
+			wantedTags:     nil,
+			wantedVolumeID: "",
+			wantedErr:      true,
+		},
+		{
+			name:           "csi and missing csi source",
+			provisionedBy:  GCP_PD_CSI,
+			tagsAnnotation: "{\"foo\": \"bar\"}",
+			volumeName:     volumeName,
+			source:         "",
 			wantedTags:     nil,
 			wantedVolumeID: "",
 			wantedErr:      true,
@@ -1029,26 +1045,22 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 				"volume.kubernetes.io/storage-provisioner": tt.provisionedBy,
 			})
 
-			var pvSpec corev1.PersistentVolumeSpec
-			if tt.provisionedBy == GCP_PD_CSI {
-				pvSpec = corev1.PersistentVolumeSpec{
-					StorageClassName: dummyStorageClassName,
-					PersistentVolumeSource: corev1.PersistentVolumeSource{
-						CSI: &corev1.CSIPersistentVolumeSource{
-							VolumeHandle: tt.wantedVolumeID,
-						},
-					},
+			pvSpec := corev1.PersistentVolumeSpec{
+				StorageClassName:       dummyStorageClassName,
+				PersistentVolumeSource: corev1.PersistentVolumeSource{},
+			}
+
+			switch tt.source {
+			case "csi":
+				pvSpec.PersistentVolumeSource.CSI = &corev1.CSIPersistentVolumeSource{
+					VolumeHandle: tt.wantedVolumeID,
 				}
-			} else {
-				pvSpec = corev1.PersistentVolumeSpec{
-					StorageClassName: dummyStorageClassName,
-					PersistentVolumeSource: corev1.PersistentVolumeSource{
-						GCEPersistentDisk: &corev1.GCEPersistentDiskVolumeSource{
-							PDName: tt.volumeID,
-						},
-					},
+			case "gce":
+				pvSpec.PersistentVolumeSource.GCEPersistentDisk = &corev1.GCEPersistentDiskVolumeSource{
+					PDName: tt.volumeID,
 				}
 			}
+
 			pv := &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        tt.volumeName,


### PR DESCRIPTION
This PVC causes k8s-pvc-tagger pods to crash loop in my GKE cluster.

It is due to a panic:

```
...
main.processPersistentVolumeClaim(0xc0007b3c20)
	/build/kubernetes.go:619 +0x505
```

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: pd.csi.storage.gke.io
    volume.kubernetes.io/storage-provisioner: pd.csi.storage.gke.io
  creationTimestamp: "2025-03-04T13:54:28Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    component: my-component
  name: my-component-pvc
  namespace: default
  resourceVersion: "1416229801"
  uid: d1c6b637-133b-4bc1-a5f0-9868ce22684a
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 500Mi
  storageClassName: standard
  volumeMode: Filesystem
  volumeName: pvc-d1c6b637-133b-4bc1-a5f0-9868ce22684a
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
```