### PR TITLE
Extend chart to allow extraObjects through values file

### DIFF
--- a/charts/k8s-pvc-tagger/Chart.yaml
+++ b/charts/k8s-pvc-tagger/Chart.yaml
@@ -20,5 +20,5 @@ keywords:
 sources:
   - https://github.com/mtougeron/k8s-pvc-tagger
 
-version: 2.3.1
+version: 2.3.2
 appVersion: v1.2.1

--- a/charts/k8s-pvc-tagger/templates/extra-manifests.yaml
+++ b/charts/k8s-pvc-tagger/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/k8s-pvc-tagger/values.yaml
+++ b/charts/k8s-pvc-tagger/values.yaml
@@ -86,6 +86,8 @@ debug: false
 extraEnvs: {}
 extraArgs: {}
 
+extraObjects: {}
+
 podLabels: {}
 
 dnsPolicy: ""

--- a/charts/k8s-pvc-tagger/values.yaml
+++ b/charts/k8s-pvc-tagger/values.yaml
@@ -87,6 +87,18 @@ extraEnvs: {}
 extraArgs: {}
 
 extraObjects: {}
+#  - apiVersion: cilium.io/v2
+#    kind: CiliumNetworkPolicy
+#    metadata:
+#      name: k8s-pvc-tagger
+#      namespace: k8s-pvc-tagger
+#    spec:
+#      endpointSelector:
+#        matchLabels:
+#          io.cilium.k8s.policy.serviceaccount: k8s-pvc-tagger
+#      egress:
+#        - toEntities:
+#            - kube-apiserver
 
 podLabels: {}
 

--- a/charts/k8s-pvc-tagger/values.yaml
+++ b/charts/k8s-pvc-tagger/values.yaml
@@ -37,6 +37,9 @@ securityContext: {}
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+  # allowPrivilegeEscalation: false
   # runAsNonRoot: true
   # runAsUser: 1000
 


### PR DESCRIPTION
This simply allows the addition of further resources through "extraObjects" in the values file, e.g. network policies.