### PR TITLE
feat:  Support Azure Work Load Identity Based authentication

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -33,16 +33,31 @@ type azureClient struct {
 }
 
 func NewAzureClient() (AzureClient, error) {
-	creds, err := azidentity.NewDefaultAzureCredential(nil)
+	var creds azcore.TokenCredential
+	var err error
+
+	// Try workload identity credential first
+	creds, err = azidentity.NewWorkloadIdentityCredential(nil)
 	if err != nil {
-		return nil, err
+		// Fallback to default azure credential if workload identity fails
+		creds, err = azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, err
+		}
 	}
-	client, err := armresources.NewTagsClient("", creds, &arm.ClientOptions{})
+
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	if subscriptionID == "" {
+		return nil, errors.New("environment variable AZURE_SUBSCRIPTION_ID is not set")
+	}
+
+	client, err := armresources.NewTagsClient(subscriptionID, creds, &arm.ClientOptions{})
+
 	if err != nil {
 		return nil, err
 	}
 
-	return azureClient{client}, err
+	return azureClient{client}, nil
 }
 
 func diskScope(subscription string, resourceGroupName string, diskName string) string {

--- a/azure.go
+++ b/azure.go
@@ -8,10 +8,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"maps"
 	"strings"
+	"os"
 )
 
 var (

--- a/azure.go
+++ b/azure.go
@@ -57,7 +57,7 @@ func NewAzureClient() (AzureClient, error) {
 		return nil, err
 	}
 
-	return azureClient{client}, nil
+	return azureClient{client}, err
 }
 
 func diskScope(subscription string, resourceGroupName string, diskName string) string {

--- a/azure.go
+++ b/azure.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"maps"
-	"strings"
 	"os"
+	"strings"
 )
 
 var (
@@ -54,7 +54,6 @@ func NewAzureClient() (AzureClient, error) {
 	}
 
 	client, err := armresources.NewTagsClient(subscriptionID, creds, &arm.ClientOptions{})
-
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +66,6 @@ func diskScope(subscription string, resourceGroupName string, diskName string) s
 }
 
 func (self azureClient) GetDiskTags(ctx context.Context, subscription AzureSubscription, resourceGroupName string, diskName string) (DiskTags, error) {
-
 	tags, err := self.client.GetAtScope(ctx, diskScope(subscription, resourceGroupName, diskName), &armresources.TagsClientGetAtScopeOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get the tags for: %w", err)
@@ -83,7 +81,8 @@ func (self azureClient) SetDiskTags(ctx context.Context, subscription AzureSubsc
 		armresources.TagsPatchResource{
 			to.Ptr(armresources.TagsPatchOperationReplace),
 			&armresources.Tags{Tags: tags},
-		}, &armresources.TagsClientUpdateAtScopeOptions{},
+		},
+		&armresources.TagsClientUpdateAtScopeOptions{},
 	)
 	if err != nil {
 		return fmt.Errorf("could not set the tags for: %w", err)


### PR DESCRIPTION
Title: Support Azure Workload Identity Based Authentication

Description:
This PR adds support for authenticating with Azure Workload Identity in k8s-pvc-tagger.
It addresses [Issue #118](https://github.com/mtougeron/k8s-pvc-tagger/issues/118) by enabling the controller to use workload identity instead of service principal credentials or federated token fallback.

Changes:

Added Azure Workload Identity authentication support.

Updated authentication fallback logic.

