### PR TITLE
Another fix to avoid publishing 'latest' container tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
           build-args: VERSION=${{ steps.docker_meta.outputs.version }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: ${{ steps.docker_meta.outputs.version }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
       - uses: sigstore/cosign-installer@main


### PR DESCRIPTION
/bug 