### PR TITLE
fix: Check PV annotation for pv.kubernetes.io/provisioned-by when PVC annotation lookup fails

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -146,28 +147,23 @@ func watchForPersistentVolumeClaims(ctx context.Context, ch chan struct{}, watch
 			pvc := getPVC(obj)
 			log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName()}).Infoln("New PVC Added to Store")
 
-			volumeID, tags, err := processPersistentVolumeClaim(pvc)
+			volumeID, tags, provisionedBy, err := processPersistentVolumeClaim(pvc)
 			if err != nil || len(tags) == 0 {
 				return
 			}
 
 			switch cloud {
 			case AWS:
-				if !provisionedByAwsEfs(pvc) && !provisionedByAwsEbs(pvc) && !provisionedByAwsFsx(pvc) {
-					return
-				}
-
-				if provisionedByAwsEfs(pvc) {
+				switch provisionedBy {
+				case AWS_EFS_CSI:
 					efsClient.addEFSVolumeTags(volumeID, tags, *pvc.Spec.StorageClassName)
-				}
-				if provisionedByAwsEbs(pvc) {
+				case AWS_EBS_CSI, AWS_EBS_LEGACY:
 					ec2Client.addEBSVolumeTags(volumeID, tags, *pvc.Spec.StorageClassName)
-				}
-				if provisionedByAwsFsx(pvc) {
+				case AWS_FSX_CSI:
 					fsxClient.addFSxVolumeTags(volumeID, tags, *pvc.Spec.StorageClassName)
 				}
 			case AZURE:
-				if provisionedByAzureDisk(pvc) {
+				if provisionedBy == AZURE_DISK_CSI {
 					err = UpdateAzureVolumeTags(context.Background(), azureClient, volumeID, tags, []string{}, *pvc.Spec.StorageClassName)
 					if err != nil {
 						log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName(), "error": err.Error()}).Error("failed to update persistent volume")
@@ -175,7 +171,7 @@ func watchForPersistentVolumeClaims(ctx context.Context, ch chan struct{}, watch
 				}
 
 			case GCP:
-				if !provisionedByGcpPD(pvc) {
+				if provisionedBy != GCP_PD_CSI && provisionedBy != GCP_PD_LEGACY {
 					return
 				}
 				addPDVolumeLabels(gcpClient, volumeID, tags, *pvc.Spec.StorageClassName)
@@ -197,31 +193,35 @@ func watchForPersistentVolumeClaims(ctx context.Context, ch chan struct{}, watch
 				log.WithFields(log.Fields{"namespace": newPVC.GetNamespace(), "pvc": newPVC.GetName()}).Debugln("PersistentVolumeClaim is being deleted")
 				return
 			}
+
+			oldTags := buildTags(oldPVC)
+			newTags := buildTags(newPVC)
+			if reflect.DeepEqual(oldTags, newTags) {
+				return
+			}
 			log.WithFields(log.Fields{"namespace": newPVC.GetNamespace(), "pvc": newPVC.GetName()}).Infoln("Need to reconcile tags")
 
-			volumeID, tags, err := processPersistentVolumeClaim(newPVC)
+			volumeID, tags, provisionedBy, err := processPersistentVolumeClaim(newPVC)
 			if err != nil {
 				return
 			}
 
 			switch cloud {
 			case AWS:
-				if !provisionedByAwsEfs(newPVC) && !provisionedByAwsEbs(newPVC) && !provisionedByAwsFsx(newPVC) {
+				if provisionedBy != AWS_EFS_CSI && provisionedBy != AWS_EBS_CSI && provisionedBy != AWS_EBS_LEGACY && provisionedBy != AWS_FSX_CSI {
 					return
 				}
 
 				if len(tags) > 0 {
-					if provisionedByAwsEfs(newPVC) {
+					switch provisionedBy {
+					case AWS_EFS_CSI:
 						efsClient.addEFSVolumeTags(volumeID, tags, *newPVC.Spec.StorageClassName)
-					}
-					if provisionedByAwsEbs(newPVC) {
+					case AWS_EBS_CSI, AWS_EBS_LEGACY:
 						ec2Client.addEBSVolumeTags(volumeID, tags, *newPVC.Spec.StorageClassName)
-					}
-					if provisionedByAwsFsx(newPVC) {
+					case AWS_FSX_CSI:
 						fsxClient.addFSxVolumeTags(volumeID, tags, *newPVC.Spec.StorageClassName)
 					}
 				}
-				oldTags := buildTags(oldPVC)
 				var deletedTags []string
 				var deletedTagsPtr []*string
 				for k := range oldTags {
@@ -231,22 +231,20 @@ func watchForPersistentVolumeClaims(ctx context.Context, ch chan struct{}, watch
 					}
 				}
 				if len(deletedTags) > 0 {
-					if provisionedByAwsEfs(newPVC) {
+					switch provisionedBy {
+					case AWS_EFS_CSI:
 						efsClient.deleteEFSVolumeTags(volumeID, deletedTags, *oldPVC.Spec.StorageClassName)
-					}
-					if provisionedByAwsEbs(newPVC) {
+					case AWS_EBS_CSI, AWS_EBS_LEGACY:
 						ec2Client.deleteEBSVolumeTags(volumeID, deletedTags, *oldPVC.Spec.StorageClassName)
-					}
-					if provisionedByAwsFsx(newPVC) {
+					case AWS_FSX_CSI:
 						fsxClient.deleteFSxVolumeTags(volumeID, deletedTagsPtr, *oldPVC.Spec.StorageClassName)
 					}
 				}
 			case AZURE:
-				if !provisionedByAzureDisk(newPVC) {
+				if provisionedBy != AZURE_DISK_CSI {
 					return
 				}
 				var deletedTags []string
-				oldTags := buildTags(oldPVC)
 				for k := range oldTags {
 					if _, ok := tags[k]; !ok {
 						deletedTags = append(deletedTags, k)
@@ -257,14 +255,13 @@ func watchForPersistentVolumeClaims(ctx context.Context, ch chan struct{}, watch
 					log.WithFields(log.Fields{"namespace": newPVC.GetNamespace(), "pvc": newPVC.GetName()}).Error("failed to update persistent volume")
 				}
 			case GCP:
-				if !provisionedByGcpPD(newPVC) {
+				if provisionedBy != GCP_PD_CSI && provisionedBy != GCP_PD_LEGACY {
 					return
 				}
 
 				if len(tags) > 0 {
 					addPDVolumeLabels(gcpClient, volumeID, tags, *newPVC.Spec.StorageClassName)
 				}
-				oldTags := buildTags(oldPVC)
 				var deletedTags []string
 				for k := range oldTags {
 					if _, ok := tags[k]; !ok {
@@ -617,10 +614,10 @@ func shouldIgnore(pvc *corev1.PersistentVolumeClaim) bool {
 	return false
 }
 
-func processPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) (string, map[string]string, error) {
+func processPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) (string, map[string]string, string, error) {
 	// Check for ignore annotation early and stop processing if found
 	if shouldIgnore(pvc) {
-		return "", nil, nil
+		return "", nil, "", nil
 	}
 
 	tags := buildTags(pvc)
@@ -630,20 +627,15 @@ func processPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) (string, ma
 	pv, err := k8sClient.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 	if err != nil {
 		log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName()}).Errorln("Get PV from kubernetes cluster error:", err)
-		return "", nil, err
+		return "", nil, "", err
 	}
 
 	var volumeID string
 	annotations := pvc.GetAnnotations()
-	if annotations == nil {
-		log.Errorf("cannot get PVC annotations")
-		return "", nil, errors.New("cannot get PVC annotations")
-	}
-
-	provisionedBy, ok := getProvisionedBy(annotations)
+	provisionedBy, ok := getProvisionedByFromPVCAndPV(annotations, pv.GetAnnotations())
 	if !ok {
-		log.Errorf("cannot get volume.kubernetes.io/storage-provisioner annotation")
-		return "", nil, errors.New("cannot get volume.kubernetes.io/storage-provisioner annotation")
+		log.Errorf("cannot get provisioner annotation; checked keys: volume.kubernetes.io/storage-provisioner, volume.beta.kubernetes.io/storage-provisioner, pv.kubernetes.io/provisioned-by")
+		return "", nil, "", errors.New("cannot get provisioner annotation; checked keys: volume.kubernetes.io/storage-provisioner, volume.beta.kubernetes.io/storage-provisioner, pv.kubernetes.io/provisioned-by")
 	}
 
 	switch provisionedBy {
@@ -670,10 +662,10 @@ func processPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) (string, ma
 	log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName(), "volumeID": volumeID}).Debugln("parsed volumeID:", volumeID)
 	if len(volumeID) == 0 {
 		log.Errorf("Cannot parse VolumeID")
-		return "", nil, errors.New("cannot parse VolumeID")
+		return "", nil, "", errors.New("cannot parse VolumeID")
 	}
 
-	return volumeID, tags, nil
+	return volumeID, tags, provisionedBy, nil
 }
 
 func getCurrentNamespace() string {
@@ -692,6 +684,19 @@ func getProvisionedBy(annotations map[string]string) (string, bool) {
 	provisionedBy, ok := annotations["volume.kubernetes.io/storage-provisioner"]
 	if !ok {
 		provisionedBy, ok = annotations["volume.beta.kubernetes.io/storage-provisioner"]
+	}
+
+	return provisionedBy, ok
+}
+
+func getProvisionedByFromPVCAndPV(pvcAnnotations map[string]string, pvAnnotations map[string]string) (string, bool) {
+	provisionedBy, ok := getProvisionedBy(pvcAnnotations)
+	if ok {
+		return provisionedBy, true
+	}
+
+	if pvAnnotations != nil {
+		provisionedBy, ok = pvAnnotations["pv.kubernetes.io/provisioned-by"]
 	}
 
 	return provisionedBy, ok

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -775,6 +775,68 @@ func Test_annotationPrefix(t *testing.T) {
 	}
 }
 
+func Test_getProvisionedByFromPVCAndPV(t *testing.T) {
+	tests := []struct {
+		name           string
+		pvcAnnotations map[string]string
+		pvAnnotations  map[string]string
+		want           string
+		wantOK         bool
+	}{
+		{
+			name:           "PVC volume.kubernetes.io/storage-provisioner",
+			pvcAnnotations: map[string]string{"volume.kubernetes.io/storage-provisioner": AWS_EBS_CSI},
+			want:           AWS_EBS_CSI,
+			wantOK:         true,
+		},
+		{
+			name:           "PVC volume.beta.kubernetes.io/storage-provisioner",
+			pvcAnnotations: map[string]string{"volume.beta.kubernetes.io/storage-provisioner": AWS_EBS_CSI},
+			want:           AWS_EBS_CSI,
+			wantOK:         true,
+		},
+		{
+			name:           "PV fallback when PVC has no provisioner",
+			pvcAnnotations: map[string]string{},
+			pvAnnotations:  map[string]string{"pv.kubernetes.io/provisioned-by": AWS_EBS_CSI},
+			want:           AWS_EBS_CSI,
+			wantOK:         true,
+		},
+		{
+			name:           "PVC takes precedence over PV",
+			pvcAnnotations: map[string]string{"volume.kubernetes.io/storage-provisioner": AWS_EBS_CSI},
+			pvAnnotations:  map[string]string{"pv.kubernetes.io/provisioned-by": AWS_EFS_CSI},
+			want:           AWS_EBS_CSI,
+			wantOK:         true,
+		},
+		{
+			name:           "no provisioner on PVC or PV",
+			pvcAnnotations: map[string]string{},
+			pvAnnotations:  map[string]string{},
+			want:           "",
+			wantOK:         false,
+		},
+		{
+			name:           "nil PV annotations",
+			pvcAnnotations: map[string]string{},
+			pvAnnotations:  nil,
+			want:           "",
+			wantOK:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := getProvisionedByFromPVCAndPV(tt.pvcAnnotations, tt.pvAnnotations)
+			if ok != tt.wantOK {
+				t.Errorf("getProvisionedByFromPVCAndPV() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("getProvisionedByFromPVCAndPV() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_processEBSPersistentVolumeClaim(t *testing.T) {
 	volumeName := "pvc-1234"
 	pvc := &corev1.PersistentVolumeClaim{}
@@ -782,14 +844,15 @@ func Test_processEBSPersistentVolumeClaim(t *testing.T) {
 	pvc.Spec.VolumeName = volumeName
 
 	tests := []struct {
-		name           string
-		provisionedBy  string
-		tagsAnnotation string
-		volumeID       string
-		volumeName     string
-		wantedTags     map[string]string
-		wantedVolumeID string
-		wantedErr      bool
+		name                string
+		provisionedBy       string
+		tagsAnnotation      string
+		volumeID            string
+		volumeName          string
+		provisionerOnPVOnly bool
+		wantedTags          map[string]string
+		wantedVolumeID      string
+		wantedErr           bool
 	}{
 		{
 			name:           "csi with valid tags and volume id",
@@ -799,6 +862,16 @@ func Test_processEBSPersistentVolumeClaim(t *testing.T) {
 			wantedTags:     map[string]string{"foo": "bar"},
 			wantedVolumeID: "vol-12345",
 			wantedErr:      false,
+		},
+		{
+			name:                "csi with provisioner on PV only",
+			provisionedBy:       AWS_EBS_CSI,
+			tagsAnnotation:      "{\"foo\": \"bar\"}",
+			volumeName:          volumeName,
+			provisionerOnPVOnly: true,
+			wantedTags:          map[string]string{"foo": "bar"},
+			wantedVolumeID:      "vol-12345",
+			wantedErr:           false,
 		},
 		{
 			name:           "in-tree with valid tags and volume id",
@@ -842,10 +915,13 @@ func Test_processEBSPersistentVolumeClaim(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pvc.SetAnnotations(map[string]string{
-				annotationPrefix + "/tags":                 tt.tagsAnnotation,
-				"volume.kubernetes.io/storage-provisioner": tt.provisionedBy,
-			})
+			pvcAnnotations := map[string]string{
+				annotationPrefix + "/tags": tt.tagsAnnotation,
+			}
+			if !tt.provisionerOnPVOnly {
+				pvcAnnotations["volume.kubernetes.io/storage-provisioner"] = tt.provisionedBy
+			}
+			pvc.SetAnnotations(pvcAnnotations)
 
 			var pvSpec corev1.PersistentVolumeSpec
 			if tt.provisionedBy == AWS_EBS_CSI {
@@ -867,15 +943,19 @@ func Test_processEBSPersistentVolumeClaim(t *testing.T) {
 					},
 				}
 			}
+			pvAnnotations := map[string]string{}
+			if tt.provisionerOnPVOnly {
+				pvAnnotations["pv.kubernetes.io/provisioned-by"] = tt.provisionedBy
+			}
 			pv := &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        tt.volumeName,
-					Annotations: map[string]string{},
+					Annotations: pvAnnotations,
 				},
 				Spec: pvSpec,
 			}
 			k8sClient = fake.NewSimpleClientset(pv)
-			volumeID, tags, err := processPersistentVolumeClaim(pvc)
+			volumeID, tags, provisionedBy, err := processPersistentVolumeClaim(pvc)
 			if (err == nil) == tt.wantedErr {
 				t.Errorf("processPersistentVolumeClaim() err = %v, wantedErr %v", err, tt.wantedErr)
 			}
@@ -884,6 +964,9 @@ func Test_processEBSPersistentVolumeClaim(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tags, tt.wantedTags) {
 				t.Errorf("processPersistentVolumeClaim() tags = %v, want %v", tags, tt.wantedTags)
+			}
+			if tt.provisionerOnPVOnly && provisionedBy != tt.provisionedBy {
+				t.Errorf("processPersistentVolumeClaim() provisionedBy = %v, want %v", provisionedBy, tt.provisionedBy)
 			}
 		})
 	}
@@ -896,14 +979,15 @@ func Test_processEFSPersistentVolumeClaim(t *testing.T) {
 	pvc.Spec.VolumeName = volumeName
 
 	tests := []struct {
-		name           string
-		provisionedBy  string
-		tagsAnnotation string
-		volumeID       string
-		volumeName     string
-		wantedTags     map[string]string
-		wantedVolumeID string
-		wantedErr      bool
+		name                string
+		provisionedBy       string
+		tagsAnnotation      string
+		volumeID            string
+		volumeName          string
+		provisionerOnPVOnly bool
+		wantedTags          map[string]string
+		wantedVolumeID      string
+		wantedErr           bool
 	}{
 		{
 			name:           "csi with valid tags and volume id",
@@ -914,6 +998,17 @@ func Test_processEFSPersistentVolumeClaim(t *testing.T) {
 			wantedTags:     map[string]string{"foo": "bar"},
 			wantedVolumeID: "fsap-06cc098e562d23425",
 			wantedErr:      false,
+		},
+		{
+			name:                "csi with provisioner on PV only",
+			provisionedBy:       AWS_EFS_CSI,
+			tagsAnnotation:      "{\"foo\": \"bar\"}",
+			volumeName:          volumeName,
+			volumeID:            "fs-05b82f74723423::fsap-06cc098e562d23425",
+			provisionerOnPVOnly: true,
+			wantedTags:          map[string]string{"foo": "bar"},
+			wantedVolumeID:      "fsap-06cc098e562d23425",
+			wantedErr:           false,
 		},
 		{
 			name:           "csi with valid tags and invalid volume id",
@@ -947,10 +1042,13 @@ func Test_processEFSPersistentVolumeClaim(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pvc.SetAnnotations(map[string]string{
-				annotationPrefix + "/tags":                 tt.tagsAnnotation,
-				"volume.kubernetes.io/storage-provisioner": tt.provisionedBy,
-			})
+			pvcAnnotations := map[string]string{
+				annotationPrefix + "/tags": tt.tagsAnnotation,
+			}
+			if !tt.provisionerOnPVOnly {
+				pvcAnnotations["volume.kubernetes.io/storage-provisioner"] = tt.provisionedBy
+			}
+			pvc.SetAnnotations(pvcAnnotations)
 
 			var pvSpec corev1.PersistentVolumeSpec
 			if tt.provisionedBy == AWS_EFS_CSI {
@@ -962,15 +1060,19 @@ func Test_processEFSPersistentVolumeClaim(t *testing.T) {
 					},
 				}
 			}
+			pvAnnotations := map[string]string{}
+			if tt.provisionerOnPVOnly {
+				pvAnnotations["pv.kubernetes.io/provisioned-by"] = tt.provisionedBy
+			}
 			pv := &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        tt.volumeName,
-					Annotations: map[string]string{},
+					Annotations: pvAnnotations,
 				},
 				Spec: pvSpec,
 			}
 			k8sClient = fake.NewSimpleClientset(pv)
-			volumeID, tags, err := processPersistentVolumeClaim(pvc)
+			volumeID, tags, provisionedBy, err := processPersistentVolumeClaim(pvc)
 			if (err == nil) == tt.wantedErr {
 				t.Errorf("processPersistentVolumeClaim() err = %v, wantedErr %v", err, tt.wantedErr)
 			}
@@ -979,6 +1081,9 @@ func Test_processEFSPersistentVolumeClaim(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tags, tt.wantedTags) {
 				t.Errorf("processPersistentVolumeClaim() tags = %v, want %v", tags, tt.wantedTags)
+			}
+			if tt.provisionerOnPVOnly && provisionedBy != tt.provisionedBy {
+				t.Errorf("processPersistentVolumeClaim() provisionedBy = %v, want %v", provisionedBy, tt.provisionedBy)
 			}
 		})
 	}
@@ -990,10 +1095,12 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 	tests := []struct {
 		name           string
 		pvcAnnotations map[string]string
+		pvAnnotations  map[string]string
 		pvSource       corev1.PersistentVolumeSource
 		pvName         string
 		wantedVolumeID string
 		wantedTags     map[string]string
+		wantedProvisioner string
 		wantedErr      bool
 	}{
 		{
@@ -1010,6 +1117,24 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			pvName:         volumeName,
 			wantedVolumeID: "projects/my-project/zones/us-east1-a/disks/my-disk",
 			wantedTags:     map[string]string{"foo": "bar"},
+		},
+		{
+			name: "csi provisioner on PV only",
+			pvcAnnotations: map[string]string{
+				annotationPrefix + "/tags": "{\"foo\": \"bar\"}",
+			},
+			pvAnnotations: map[string]string{
+				"pv.kubernetes.io/provisioned-by": GCP_PD_CSI,
+			},
+			pvSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					VolumeHandle: "projects/my-project/zones/us-east1-a/disks/my-disk",
+				},
+			},
+			pvName:            volumeName,
+			wantedVolumeID:    "projects/my-project/zones/us-east1-a/disks/my-disk",
+			wantedTags:        map[string]string{"foo": "bar"},
+			wantedProvisioner: GCP_PD_CSI,
 		},
 		{
 			name: "legacy in-tree provisioner with legacy in-tree volume source",
@@ -1123,7 +1248,8 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			// setup PV
 			pv := &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: tt.pvName,
+					Name:        tt.pvName,
+					Annotations: tt.pvAnnotations,
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					StorageClassName:       dummyStorageClassName,
@@ -1132,7 +1258,7 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			}
 
 			k8sClient = fake.NewSimpleClientset(pv)
-			volumeID, tags, err := processPersistentVolumeClaim(pvc)
+			volumeID, tags, provisionedBy, err := processPersistentVolumeClaim(pvc)
 
 			if (err == nil) == tt.wantedErr {
 				t.Errorf("processPersistentVolumeClaim() err = %v, wantedErr %v", err, tt.wantedErr)
@@ -1142,6 +1268,9 @@ func Test_processGCPPDPersistentVolumeClaim(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tags, tt.wantedTags) {
 				t.Errorf("processPersistentVolumeClaim() tags = %v, want %v", tags, tt.wantedTags)
+			}
+			if tt.wantedProvisioner != "" && provisionedBy != tt.wantedProvisioner {
+				t.Errorf("processPersistentVolumeClaim() provisionedBy = %v, want %v", provisionedBy, tt.wantedProvisioner)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary  
This PR fixes two user-visible issues in k8s-pvc-tagger:

1. Provisioner lookup failures for CSI PVC/PV flows
2. High-volume no-op update reconciles causing repeated info logs

## Problem  
Users reported these log lines:

```json
{"level":"error","msg":"cannot get volume.kubernetes.io/storage-provisioner annotation","namespace":"<ns>","pvc":"<pvc-name>"}
```

and later, after initial fix attempt, continued high-frequency logs:

```json
{"level":"info","msg":"Need to reconcile tags","namespace":"<ns>","pvc":"<pvc-name>"}
```

## Root causes:

- Provisioner detection relied on PVC annotation keys in handler decision paths, while CSI provisioners may only expose the provisioner on the PV via `pv.kubernetes.io/provisioned-by`.
- Update handler reconciled on resource churn even when effective desired tags were unchanged.

## What changed  
1. Unified provisioner resolution path
- `processPersistentVolumeClaim` now resolves and returns `provisionedBy`.
- Resolution order:
  - PVC: `volume.kubernetes.io/storage-provisioner`
  - PVC: `volume.beta.kubernetes.io/storage-provisioner`
  - PV fallback: `pv.kubernetes.io/provisioned-by`

2. Removed PVC-only gating drift in Add/Update flow
- Add/Update handlers now use the resolved `provisionedBy` returned by `processPersistentVolumeClaim`.
- This avoids split behavior where parse path succeeded but handler gating still failed on PVC-only checks.

3. Reduced no-op reconcile spam
- Update handler now computes old/new desired tag maps and returns early when they are equal.
- This prevents unnecessary tag operations and reduces repeated:
  - `Need to reconcile tags`

4. Tests updated
- Unit tests updated for `processPersistentVolumeClaim` return signature change.
- Test run passes.

## Behavior after this PR  
- CSI volumes are handled correctly even when PVC provisioner keys are absent.
- Legacy/in-tree and CSI behavior remains compatible across AWS/Azure/GCP.
- No-op update events no longer flood reconcile info logs.

## Validation  
- Tests:
  - `CGO_ENABLED=0 go test ./...` ✅
- Container build:
  - `docker build ...` ✅
- Arm64 image build/push for validation ✅

## Issue linkage  
This PR addresses both searchable symptoms from issue #134:

- `cannot get volume.kubernetes.io/storage-provisioner annotation`
- `Need to reconcile tags`