### PR TITLE
support efs: at the start of efs csi drivers

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -56,7 +56,7 @@ var (
 
 const (
 	// Matching strings for volume operations.
-	regexpEFSVolumeID = `^fs-\w+::(fsap-\w+)$`
+	regexpEFSVolumeID = `^(?:efs:)?fs-\w+::(fsap-\w+)$`
 
 	// supported AWS storage provisioners:
 	AWS_EBS_CSI_AUTO = "ebs.csi.eks.amazonaws.com"

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -82,8 +82,18 @@ func Test_parseAWSEFSVolumeID(t *testing.T) {
 			want:        "fsap-06cc098e562d24942",
 		},
 		{
+			name:        "full AWS-EFS.VolumeID - with efs:",
+			k8sVolumeID: "efs:fs-05b82f747004ac501::fsap-06cc098e562d24942",
+			want:        "fsap-06cc098e562d24942",
+		},
+		{
 			name:        "invalid AWS-EFS.VolumeID",
 			k8sVolumeID: "fsp-05b82f747004ac501::fsap-06cc098e562d24942",
+			want:        "",
+		},
+		{
+			name:        "invalid AWS-EFS.VolumeID with efs:",
+			k8sVolumeID: "efs:fsp-05b82f747004ac501::fsap-06cc098e562d24942",
 			want:        "",
 		},
 		{
@@ -1009,6 +1019,16 @@ func Test_processEFSPersistentVolumeClaim(t *testing.T) {
 			tagsAnnotation: "{\"foo\": \"bar\"}",
 			volumeName:     volumeName,
 			volumeID:       "fs-05b82f74723423::fsap-06cc098e562d23425",
+			wantedTags:     map[string]string{"foo": "bar"},
+			wantedVolumeID: "fsap-06cc098e562d23425",
+			wantedErr:      false,
+		},
+		{
+			name:           "csi with valid tags and volume id - with efs in volumeId",
+			provisionedBy:  AWS_EFS_CSI,
+			tagsAnnotation: "{\"foo\": \"bar\"}",
+			volumeName:     volumeName,
+			volumeID:       "efs:fs-05b82f74723423::fsap-06cc098e562d23425",
 			wantedTags:     map[string]string{"foo": "bar"},
 			wantedVolumeID: "fsap-06cc098e562d23425",
 			wantedErr:      false,


### PR DESCRIPTION
Noticed my deployment was failing to parse out some of my AWS EFS pv's and tracked it back to some newer ones in auto mode being tagged as 
"efs:<normal efs tagging>"

Updated the regex that finds efs volume ID's to be able to work with this format