### PR TITLE
Fix tagging reconcile loop miss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+/k8s-pvc-tagger
 
 # Test binary, built with `go test -c`
 *.test

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -148,6 +148,11 @@ func watchForPersistentVolumeClaims(ctx context.Context, ch chan struct{}, watch
 			pvc := getPVC(obj)
 			log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName()}).Infoln("New PVC Added to Store")
 
+			if pvc.Spec.VolumeName == "" {
+				log.WithFields(log.Fields{"namespace": pvc.GetNamespace(), "pvc": pvc.GetName()}).Debugln("PersistentVolume not created yet")
+				return
+			}
+
 			volumeID, tags, provisionedBy, err := processPersistentVolumeClaim(pvc)
 			if err != nil || len(tags) == 0 {
 				return
@@ -197,7 +202,7 @@ func watchForPersistentVolumeClaims(ctx context.Context, ch chan struct{}, watch
 
 			oldTags := buildTags(oldPVC)
 			newTags := buildTags(newPVC)
-			if reflect.DeepEqual(oldTags, newTags) {
+			if !shouldReconcileTags(oldPVC, newPVC, oldTags, newTags) {
 				return
 			}
 			log.WithFields(log.Fields{"namespace": newPVC.GetNamespace(), "pvc": newPVC.GetName()}).Infoln("Need to reconcile tags")
@@ -348,6 +353,17 @@ func parseAWSEFSVolumeID(k8sVolumeID string) string {
 		return ""
 	}
 	return string(matches[1])
+}
+
+// shouldReconcileTags decides whether an updated PVC's tags need to be reconciled against the
+// underlying cloud volume. It always reconciles when the PV was just bound (VolumeName newly
+// populated), since that may be the first opportunity to tag the volume even if the desired tags
+// themselves didn't change; otherwise it only reconciles when the desired tags actually differ.
+func shouldReconcileTags(oldPVC, newPVC *corev1.PersistentVolumeClaim, oldTags, newTags map[string]string) bool {
+	if oldPVC.Spec.VolumeName == "" && newPVC.Spec.VolumeName != "" {
+		return true
+	}
+	return !reflect.DeepEqual(oldTags, newTags)
 }
 
 func buildTags(pvc *corev1.PersistentVolumeClaim) map[string]string {

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -790,6 +790,62 @@ func Test_annotationPrefix(t *testing.T) {
 	}
 }
 
+func Test_shouldReconcileTags(t *testing.T) {
+	tests := []struct {
+		name          string
+		oldVolumeName string
+		newVolumeName string
+		oldTags       map[string]string
+		newTags       map[string]string
+		want          bool
+	}{
+		{
+			name:          "newly bound with identical tags still reconciles",
+			oldVolumeName: "",
+			newVolumeName: "pvc-1234",
+			oldTags:       map[string]string{"foo": "bar"},
+			newTags:       map[string]string{"foo": "bar"},
+			want:          true,
+		},
+		{
+			name:          "newly bound with different tags reconciles",
+			oldVolumeName: "",
+			newVolumeName: "pvc-1234",
+			oldTags:       map[string]string{"foo": "bar"},
+			newTags:       map[string]string{"foo": "baz"},
+			want:          true,
+		},
+		{
+			name:          "already bound with identical tags does not reconcile",
+			oldVolumeName: "pvc-1234",
+			newVolumeName: "pvc-1234",
+			oldTags:       map[string]string{"foo": "bar"},
+			newTags:       map[string]string{"foo": "bar"},
+			want:          false,
+		},
+		{
+			name:          "already bound with different tags reconciles",
+			oldVolumeName: "pvc-1234",
+			newVolumeName: "pvc-1234",
+			oldTags:       map[string]string{"foo": "bar"},
+			newTags:       map[string]string{"foo": "baz"},
+			want:          true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPVC := &corev1.PersistentVolumeClaim{}
+			oldPVC.Spec.VolumeName = tt.oldVolumeName
+			newPVC := &corev1.PersistentVolumeClaim{}
+			newPVC.Spec.VolumeName = tt.newVolumeName
+
+			if got := shouldReconcileTags(oldPVC, newPVC, tt.oldTags, tt.newTags); got != tt.want {
+				t.Errorf("shouldReconcileTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_getProvisionedByFromPVCAndPV(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
Fixes #142 and #143.
  
PR #133 added a no-op-reconcile optimization to the PVC UpdateFunc handler that skips reconciliation whenever the desired tag maps are unchanged (reflect.DeepEqual(oldTags, newTags)). That check only compares desired tags and never accounts for whether the underlying volume was actually tagged yet, which breaks the common flow where tags are set on the PVC before the PV is provisioned:

1. A PVC is created with tags (via annotation or --default-tags).
2. AddFunc fires while pvc.Spec.VolumeName is still empty, so the Get PV lookup fails and nothing is tagged.
3. The PV binds moments later and UpdateFunc fires — but since the PVC's tags never changed, oldTags == newTags and the reconcile is silently skipped, leaving the volume permanently untagged.

This affects on-demand FSx volumes (#142) and ephemeral EBS volumes relying on default tags (#143).

Changes:
- UpdateFunc now decides whether to reconcile via a new shouldReconcileTags helper, which forces a reconcile when the PVC transitions from unbound to bound (oldPVC.Spec.VolumeName == "" && newPVC.Spec.VolumeName != "") even if the desired tags are unchanged. For all other updates the behavior is unchanged, so the no-op-reconcile log-spam fix from #133/#134 is preserved.
- AddFunc now returns early when pvc.Spec.VolumeName is empty, matching the guard UpdateFunc already had. This avoids a doomed Get PV call and the misleading Get PV from kubernetes cluster error: resource name may not be empty log line on every not-yet-bound PVC (the symptom investigated in #143). Functional recovery once the PV binds is handled entirely by the UpdateFunc change.
- Added Test_shouldReconcileTags covering the bind transition, unchanged-tags, and changed-tags cases.

/kind bug